### PR TITLE
Fix root project name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,5 +27,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Network"
+rootProject.name = "TodoApp"
 include(":app")


### PR DESCRIPTION
## Summary
- rename root project to `TodoApp`

## Testing
- `gradle -version`

------
https://chatgpt.com/codex/tasks/task_e_685a37750320832c99051b828bc15aaa