### PR TITLE
Remove redundant compose compiler dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     implementation(libs.androidx.material3)
     
     // Compose Compiler
-    implementation(libs.androidx.compose.compiler)
 
     // Networking
     implementation(libs.retrofit)


### PR DESCRIPTION
## Summary
- remove the explicit Compose compiler dependency since the compiler version is set via `composeOptions`

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_685a3776a490832cbbf7462747afde04