### PR TITLE
Update instrumentation test package name

### DIFF
--- a/app/src/androidTest/java/com/example/network/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/network/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.example.network", appContext.packageName)
+        assertEquals("com.example.todoapp", appContext.packageName)
     }
 }


### PR DESCRIPTION
## Summary
- update instrumentation test package name to `com.example.todoapp`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a377336bc832cbf925075cb9682c0